### PR TITLE
Change command to install plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ composer create-project chasegiunta/craft-vue-tailwind PATH
 ./craft setup
 
 # install the Twigpack plugin
-./craft install/plugin twigpack
+./craft plugin/install twigpack
 
 # install dependencies
 npm install # yarn


### PR DESCRIPTION
The current command for installing the twigpack is deprecated, and should be replaced with plugin/install. 